### PR TITLE
fix bug in compile_report with search pattern

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
 Package: reportfactory
 Type: Package
 Title: Report factory
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: c(person("Thibaut", "Jombart", role = c("aut", "cre"), email =
-  "thibautjombart@gmail.com"))
+  "thibautjombart@gmail.com"),
+  person("Zhian N.", "Kamvar", role = "ctb", email = "zkamvar@gmail.com"))
 Description: Scripts for compiling reports using \code{rmarkdown::render}.
 License: MIT + file LICENSE
 URL: https://github.com/reconhub/reportfactory

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,5 @@
+# reportfactory 0.0.3
+
+* fix bug where reports with identical partial slugs will cause an error
+  (See https://github.com/reconhub/reportfactory/issues/9)
+* Add NEWS

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -35,7 +35,7 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(), ...) {
   }
   rmd_path <- grep(".Rmd",
                   dir(find_file("report_sources"),
-                      recursive = TRUE, pattern = file,
+                      recursive = TRUE, pattern = sprintf("^%s$", file),
                       full.names = TRUE),
                   value = TRUE, ignore.case = TRUE)
   rmd_path <- ignore_tilde(rmd_path)

--- a/tests/testthat/test_new_factory.R
+++ b/tests/testthat/test_new_factory.R
@@ -1,5 +1,10 @@
 context("Creation of report factory")
 
+new_dir <- function() {
+  rnd  <- paste(sample(0:9, 20, replace = TRUE), collapse = "")
+  file.path(tempdir(), paste("factory_test", rnd, sep = "_"))
+}
+
 
 test_that("new_factory generates the right files - with examples", {
   
@@ -100,12 +105,6 @@ test_that("working directory unchanged", {
 
   skip_on_cran()
 
-
-  new_dir <- function() {
-    rnd  <- paste(sample(0:9, 20, replace = TRUE), collapse = "")
-    file.path(tempdir(), paste("factory_test", rnd, sep = "_"))
-  }
-
   odir <- getwd()
   new_factory(x <- new_dir(), move_in = FALSE, include_examples = TRUE)
 
@@ -132,3 +131,20 @@ test_that("working directory unchanged", {
 
 
 })
+
+
+test_that("factories with similar slugs don't cause problems", {
+
+skip_on_cran()
+odir <- getwd()
+
+reportfactory::new_factory(x <- new_dir(), move_in = FALSE)
+
+file.copy(file.path(x, "report_sources/example_report_2019-01-31.Rmd"), 
+          to = file.path(x, "report_sources/foo_example_report_2019-01-31.Rmd"))
+
+expect_output(reportfactory::update_reports(factory = x), 
+              "/// 'foo_example_report_2019-01-31' done!")
+  
+})
+


### PR DESCRIPTION
This will fix #9

It wraps the search pattern in ^ and $ so that it matches the entire string instead of matching a partial slug.

I'm not sure I understand how new_factory is working because I am getting weird results, but it works with the example @thibautjombart showed in #9 