### PR TITLE
Issue 29 - parametrisation of reports

### DIFF
--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -27,7 +27,7 @@
 #'
 
 compile_report <- function(file, quiet = FALSE, factory = getwd(),
-                           encoding = "UTF-8", ...) {
+                           encoding = "UTF-8", render_params, ...) {
 
   ## This function will:
   
@@ -87,14 +87,13 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
   
   dots <- list(...)
   has_params <- FALSE
-  if ("params" %in% names(dots)) {
-    params <- dots$params
+  if (length(render_params) > 0) {
     
     ## remove unnamed parameters
-    named <- names(params) != ""
-    params <- params[named]
+    named <- names(render_params) != ""
+    render_params <- render_params[named]
     
-    if (length(params) > 0) {
+    if (length(render_params) > 0) {
       has_params <- TRUE
 
       ## convert the parameter values to txt and abbreviate them for display to
@@ -105,8 +104,8 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
         out
       }
 
-      params_as_txt_console <- lapply(params, turn_to_character, sep = " ")
-      params_as_txt <- lapply(params, turn_to_character)
+      params_as_txt_console <- lapply(render_params, turn_to_character, sep = " ")
+      params_as_txt <- lapply(render_params, turn_to_character)
       
       long_values <- nchar(params_as_txt) > 8
       params_as_txt_console <- lapply(params_as_txt_console, substr, 1, 8)
@@ -116,14 +115,14 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
       
 
       ## create character strings to be displayed to the console
-      txt_display <- paste(names(params),
+      txt_display <- paste(names(render_params),
                            params_as_txt_console,
                            sep = ": ")
       txt_display[long_values] <- paste0(txt_display[long_values], "...")
       txt_display <- paste(txt_display, collapse = "\n")
 
       ## create character strings to be used for file naming
-      txt_name_folder <- paste(names(params), params_as_txt,
+      txt_name_folder <- paste(names(render_params), params_as_txt,
                                sep = "_", collapse = "_")
       txt_name_folder <- sub("_$", "", txt_name_folder)
 
@@ -137,7 +136,7 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
                                    quiet = quiet,
                                    encoding = encoding,
                                    envir = new.env(), # force clean environment
-                                   ...) # params can be passed here
+                                   params = render_params) # params can be passed here
   if (has_params) {
     message(sprintf("// using params: \n%s",
                     txt_display))

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -41,7 +41,6 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
   ## 4. move all outputs identified in 3. to a dedicated folder in
   ## report_outputs/
   
-  
   validate_factory(factory)
 
   odir <- getwd()
@@ -89,13 +88,12 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
   dots <- list(...)
   has_params <- FALSE
   if ("params" %in% names(dots)) {
-    ##browser()
     params <- dots$params
     
     ## remove unnamed parameters
     named <- names(params) != ""
     params <- params[named]
-
+    
     if (length(params) > 0) {
       has_params <- TRUE
 
@@ -114,6 +112,8 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
       params_as_txt_console <- lapply(params_as_txt_console, substr, 1, 8)
       params_as_txt <- lapply(params_as_txt, substr, 1, 8)
       params_as_txt <- sub("-$", "", params_as_txt)
+      params_as_txt <- sub("_$", "", params_as_txt)
+      
 
       ## create character strings to be displayed to the console
       txt_display <- paste(names(params),

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -22,6 +22,11 @@
 #'
 #' @param factory the path to a report factory; defaults to the current working
 #'   directory
+#'   
+#' @param render_params a list that is passed to the params argument in
+#'   `rmarkdown::render`, which are accessed in the .Rmd file with params$foo, and 
+#'   is used to create the subdirectory name in report-outputs;
+#'   default is an empty list
 #'
 #' @param ... further arguments passed to \code{rmarkdown::render}.
 #'

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -139,7 +139,7 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
                                    envir = new.env(), # force clean environment
                                    ...) # params can be passed here
   if (has_params) {
-    message(sprintf("\n/// using params: \n'%s'",
+    message(sprintf("// using params: \n%s",
                     txt_display))
   }
   message(sprintf("\n/// '%s' done!\n", shorthand))
@@ -168,13 +168,12 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
     output_dir <- paste0(report_dir,
                          "/compiled_",
                          txt_name_folder,
+                         "_",
                          datetime)
   } else {
     output_dir <- paste0(report_dir, "/compiled_", datetime)
   }
-    
-  output_dir <- file.path(report_dir,
-                          paste("compiled", datetime, sep = "_"))
+
   dir.create(output_dir, FALSE, TRUE)
 
   for (file in new_files) {

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -27,7 +27,7 @@
 #'
 
 compile_report <- function(file, quiet = FALSE, factory = getwd(),
-                           encoding = "UTF-8", render_params, ...) {
+                           encoding = "UTF-8", render_params = list(), ...) {
 
   ## This function will:
   

--- a/R/update_reports.R
+++ b/R/update_reports.R
@@ -45,7 +45,7 @@ update_reports <- function(factory = getwd(), all = FALSE, quiet = TRUE,
   report_sources <- list_reports(ignore_archive = ignore_archive)
   dates <- extract_date(report_sources)
   types <- extract_base(report_sources)
-
+  
   if (all) {
     lapply(report_sources,
            compile_report,

--- a/man/compile_report.Rd
+++ b/man/compile_report.Rd
@@ -5,7 +5,7 @@
 \title{Compile an rmarkdown report}
 \usage{
 compile_report(file, quiet = FALSE, factory = getwd(),
-  encoding = "UTF-8", ...)
+  encoding = "UTF-8", render_params = list(), ...)
 }
 \arguments{
 \item{file}{the full path, or a partial, unambiguous match for the Rmd
@@ -20,6 +20,11 @@ directory}
 \item{encoding}{a character string indicating which encoding should be used
 when compiling the document; defaults to `"UTF-8"`, which ensures that
 non-ascii characters work across different systems}
+
+\item{render_params}{a list that is passed to the params argument in
+`rmarkdown::render`, which are accessed in the .Rmd file with params$foo, and 
+is used to create the subdirectory name in report-outputs;
+default is an empty list}
 
 \item{...}{further arguments passed to \code{rmarkdown::render}.}
 }

--- a/tests/testthat/test_compile_report.R
+++ b/tests/testthat/test_compile_report.R
@@ -31,8 +31,10 @@ test_that("Compilation can take params and pass to markdown::render", {
   report <- list_reports(pattern = "foo")[1]
   
   foo_value <- "testzfoo"
-  update_reports(params = list(foo = foo_value, show_stuff = TRUE, bar = letters))
+  update_reports(render_params = 
+                   list(foo = foo_value, show_stuff = TRUE, bar = letters))
   
-  testthat::expect_match(list_outputs()[length(list_outputs())],
-               paste("foo", foo_value, "show_stuff_TRUE_bar_a_b_c_d", sep = "_"))
+  testthat::expect_match(
+    list_outputs()[length(list_outputs())],
+    paste("foo", foo_value, "show_stuff_TRUE_bar_a_b_c_d", sep = "_"))
 })

--- a/tests/testthat/test_compile_report.R
+++ b/tests/testthat/test_compile_report.R
@@ -5,8 +5,8 @@ test_that("Compilation can handle multiple outputs", {
   skip_on_cran()
   odir <- getwd()
   on.exit(setwd(odir))
-  setwd(tempdir())
   
+  setwd(tempdir())
   random_factory(include_examples = TRUE)
 
   compile_report(list_reports(pattern = "foo")[1], quiet = TRUE)

--- a/tests/testthat/test_compile_report.R
+++ b/tests/testthat/test_compile_report.R
@@ -2,10 +2,11 @@ context("Test report compilation")
 
 
 test_that("Compilation can handle multiple outputs", {
-
   skip_on_cran()
-
+  odir <- getwd()
+  on.exit(setwd(odir))
   setwd(tempdir())
+  
   random_factory(include_examples = TRUE)
 
   compile_report(list_reports(pattern = "foo")[1], quiet = TRUE)
@@ -17,7 +18,21 @@ test_that("Compilation can handle multiple outputs", {
            "figures/violins-1.pdf", "figures/violins-1.png",
            "foo_2018-06-29.html", "outputs_base.csv" )
 
-
   expect_identical(ref, outputs)
+})
 
+test_that("Compilation can take params and pass to markdown::render", {
+  skip_on_cran()
+  odir <- getwd()
+  on.exit(setwd(odir))
+
+  setwd(tempdir())
+  factory <- random_factory(include_examples = TRUE)
+  report <- list_reports(pattern = "foo")[1]
+  
+  foo_value <- "testzfoo"
+  update_reports(params = list(foo = foo_value, show_stuff = TRUE, bar = letters))
+  
+  testthat::expect_match(list_outputs()[length(list_outputs())],
+               paste("foo", foo_value, "show_stuff_TRUE_bar_a_b_c_d", sep = "_"))
 })


### PR DESCRIPTION
This should address https://github.com/reconhub/reportfactory/issues/29

## Outline

The implementation of parametrised reports includes the following changes to `compile_reports()`:

* grab `params` from `...` and pass it to `rmarkdown::render()`

* display the used parameters to the console as a message when compiling

* named the output directory according to the pattern: 
`compiled_[param1]_[value1]_[param2]_[value2]_..._[date-time]`

Waiting to have a decent design for automated testing for this package, I provide an example factory attached here for testing purposes.

[factory_test_params.zip](https://github.com/reconhub/reportfactory/files/3665493/factory_test_params.zip)

## Example

The patch can be installed by typing:
```r
remotes::install_github("reconhub/reportfactory@issue_29")
```

Sample code to run an example:

``` r
library(reportfactory)
setwd(tempdir())
download.file("https://github.com/reconhub/reportfactory/files/3665493/factory_test_params.zip", 
              destfile = "factory_test_params.zip")
unzip("factory_test_params.zip")
setwd("factory_test_params")
update_reports()
#> 
#> /// compiling report: 'example_2019-09-27'
#> 
#> /// 'example_2019-09-27' done!
#> 
#> /// compiling report: 'test_2019-09-24'
#> 
#> /// 'test_2019-09-24' done!
update_reports(params = list(foo = 1, show_stuff = TRUE, bar = letters))
#> 
#> /// compiling report: 'example_2019-09-27'
#> // using params: 
#> foo: 1
#> show_stuff: TRUE
#> bar: a b c d ...
#> 
#> /// 'example_2019-09-27' done!
#> 
#> /// compiling report: 'test_2019-09-24'
#> // using params: 
#> foo: 1
#> show_stuff: TRUE
#> bar: a b c d ...
#> 
#> /// 'test_2019-09-24' done!
list_outputs()
#> [1] "example_2019-09-27/compiled_2019-09-28_14-31-26/example_2019-09-27.html"                                  
#> [2] "example_2019-09-27/compiled_foo_1_show_stuff_TRUE_bar_a_b_c_d_2019-09-28_14-31-33/example_2019-09-27.html"
#> [3] "test_2019-09-24/compiled_2019-09-28_14-31-30/test_2019-09-24.html"                                        
#> [4] "test_2019-09-24/compiled_foo_1_show_stuff_TRUE_bar_a_b_c_d_2019-09-28_14-31-36/test_2019-09-24.html"
```

<sup>Created on 2019-09-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
