### PR TITLE
Issue 29 revival

### DIFF
--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -178,10 +178,16 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
 
   ## display messages to the console
   message(sprintf("\n/// compiling report: '%s'", shorthand))
+
+  ## construct the compilation environment: as 'params' seems underliable, we
+  ## pass this info by creating a new clean environment, in which we add a
+  ## `params` variable
+  compile_env <- new.env()
+  compile_env$params <- render_params
   output_file <- rmarkdown::render(rmd_path,
                                    quiet = quiet,
                                    encoding = encoding,
-                                   envir = new.env(), # force clean environment
+                                   envir = compile_env, # force clean environment
                                    params = render_params) # params can be passed here
   if (has_params) {
     message(sprintf("// using params: \n%s",

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -23,7 +23,7 @@
 #' @param factory the path to a report factory; defaults to the current working
 #'   directory
 #'   
-#' @param render_params a list that is passed to the `params` argument in
+#' @param params a list that is passed to the `params` argument in
 #'   `rmarkdown::render`, which are accessed in the `.Rmd` file with
 #'   `params$...`; for instance, if `list(foo = 1:3)` is passed, then the
 #'   compilation environment will define an object `params$foo` with value
@@ -46,7 +46,7 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
                            clean_report_sources = FALSE,
                            remove_cache = TRUE, 
                            encoding = "UTF-8",
-                           render_params = list(), ...) {
+                           params = list(), ...) {
 
   ## This function will:
   
@@ -120,19 +120,19 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
   files_before <- unique(sub("~$", "", files_before))
 
 
-  ## handle optional parameters passed `render_params`:
+  ## handle optional parameters passed `params`:
   ## we display some information to the console on parameters used, and generate
   ## some text that will be used to name the output folder
   
   dots <- list(...)
   has_params <- FALSE
-  if (length(render_params) > 0) {
+  if (length(params) > 0) {
     
     ## remove unnamed parameters
-    named <- names(render_params) != ""
-    render_params <- render_params[named]
+    named <- names(params) != ""
+    params <- params[named]
     
-    if (length(render_params) > 0) {
+    if (length(params) > 0) {
       has_params <- TRUE
 
       ## convert the parameter values to txt and abbreviate them for display to
@@ -143,8 +143,8 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
         out
       }
 
-      params_as_txt_console <- lapply(render_params, turn_to_character, sep = " ")
-      params_as_txt <- lapply(render_params, turn_to_character)
+      params_as_txt_console <- lapply(params, turn_to_character, sep = " ")
+      params_as_txt <- lapply(params, turn_to_character)
 
       ## this bit shortens param values which will be used for file names; usual
       ## filesystems (incl. ext3, ext4, NTFS, FAT32) hava a cap of 255
@@ -160,14 +160,14 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
       
 
       ## create character strings to be displayed to the console
-      txt_display <- paste(names(render_params),
+      txt_display <- paste(names(params),
                            params_as_txt_console,
                            sep = ": ")
       txt_display[long_values] <- paste0(txt_display[long_values], "...")
       txt_display <- paste(txt_display, collapse = "\n")
 
       ## create character strings to be used for file naming
-      txt_name_folder <- paste(names(render_params), params_as_txt,
+      txt_name_folder <- paste(names(params), params_as_txt,
                                sep = "_", collapse = "_")
       txt_name_folder <- substr(txt_name_folder, 1, 100)
       txt_name_folder <- sub("_$", "", txt_name_folder)
@@ -178,21 +178,21 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
 
   ## display messages to the console
   message(sprintf("\n/// compiling report: '%s'", shorthand))
+  if (has_params) {
+    message(sprintf("// using params: \n%s",
+                    txt_display))
+  }
 
   ## construct the compilation environment: as 'params' seems underliable, we
   ## pass this info by creating a new clean environment, in which we add a
   ## `params` variable
   compile_env <- new.env()
-  compile_env$params <- render_params
+  compile_env$params <- params
   output_file <- rmarkdown::render(rmd_path,
                                    quiet = quiet,
                                    encoding = encoding,
                                    envir = compile_env) # force clean environment
 
-  if (has_params) {
-    message(sprintf("// using params: \n%s",
-                    txt_display))
-  }
   message(sprintf("\n/// '%s' done!\n", shorthand))
 
   

--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -187,8 +187,8 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
   output_file <- rmarkdown::render(rmd_path,
                                    quiet = quiet,
                                    encoding = encoding,
-                                   envir = compile_env, # force clean environment
-                                   params = render_params) # params can be passed here
+                                   envir = compile_env) # force clean environment
+
   if (has_params) {
     message(sprintf("// using params: \n%s",
                     txt_display))

--- a/man/compile_report.Rd
+++ b/man/compile_report.Rd
@@ -6,7 +6,7 @@
 \usage{
 compile_report(file, quiet = FALSE, factory = getwd(),
   clean_report_sources = FALSE, remove_cache = TRUE,
-  encoding = "UTF-8", render_params = list(), ...)
+  encoding = "UTF-8", params = list(), ...)
 }
 \arguments{
 \item{file}{the full path, or a partial, unambiguous match for the Rmd
@@ -31,7 +31,7 @@ defaults to `TRUE`, in which case `cache` will also be removed if
 when compiling the document; defaults to `"UTF-8"`, which ensures that
 non-ascii characters work across different systems}
 
-\item{render_params}{a list that is passed to the `params` argument in
+\item{params}{a list that is passed to the `params` argument in
 `rmarkdown::render`, which are accessed in the `.Rmd` file with
 `params$...`; for instance, if `list(foo = 1:3)` is passed, then the
 compilation environment will define an object `params$foo` with value

--- a/tests/testthat/test_compile_report.R
+++ b/tests/testthat/test_compile_report.R
@@ -31,7 +31,7 @@ test_that("Compilation can take params and pass to markdown::render", {
   report <- list_reports(pattern = "foo")[1]
   
   foo_value <- "testzfoo"
-  update_reports(render_params = 
+  update_reports(params = 
                    list(foo = foo_value, show_stuff = TRUE, bar = letters))
   
   expect_match(

--- a/tests/testthat/test_compile_report.R
+++ b/tests/testthat/test_compile_report.R
@@ -34,7 +34,7 @@ test_that("Compilation can take params and pass to markdown::render", {
   update_reports(render_params = 
                    list(foo = foo_value, show_stuff = TRUE, bar = letters))
   
-  testthat::expect_match(
+  expect_match(
     list_outputs()[length(list_outputs())],
     paste("foo", foo_value, "show_stuff_TRUE_bar_a_b_c_d", sep = "_"))
 })
@@ -85,8 +85,8 @@ test_that("`clean_report_sources = TRUE` removes unprotected non Rmd files", {
   removed <- setdiff(orig_source_files, clean_source_files)
   removed <- paste0("report_sources/", removed)
   to_remove <- c(nested_dir, csv2_filename, empty_dirname,  csv1_filename)
-  testthat::expect_equal(length(removed), length(to_remove))
-  testthat::expect_setequal(to_remove, removed)
-  testthat::expect_equal(file.exists(protected_filename), TRUE)
+  expect_equal(length(removed), length(to_remove))
+  expect_setequal(to_remove, removed)
+  expect_equal(file.exists(protected_filename), TRUE)
 })
 


### PR DESCRIPTION
This replaces the reliance on `rmarkdown::render(params = ...)` which stopped working on two different computers / OSes / version without explanation. As a workaroun, we are now relying on something along the lines of:
```r
env <- new.env()
env$params <- params
rmarkdown::render(envir = env)
```
which seems to work. 

Problem with examples files not running, but seems like faulty code in these `Rmd`. PR-ing to see if this is platform dependent.