### PR TITLE
Issue 51

### DIFF
--- a/R/compile_report.R
+++ b/R/compile_report.R
@@ -211,7 +211,6 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
 
   files_after <- unique(ignore_tilde(files_after))
   new_files <- setdiff(files_after, files_before)
-  new_files <- c(new_files, sub(file_dir, "", output_file))
   new_files <- unique(new_files)
   new_dirs <- unique(basename(setdiff(dirs_after, dirs_before)))
 
@@ -241,6 +240,7 @@ compile_report <- function(file, quiet = FALSE, factory = getwd(),
   dir.create(output_dir, FALSE, TRUE)
   
   output_files <- vector(length(new_files), mode = "list")
+  
   for (i in seq_along(new_files)) {
     file <- new_files[i]
     destination <- file.path(output_dir, file)

--- a/R/current_compile_log.R
+++ b/R/current_compile_log.R
@@ -1,8 +1,9 @@
 current_compile_log <- function(log_file_path = getwd(), base_name, date_string) {
   no_log_file <- !any(file.exists(log_file_path, hidden.files = TRUE))
   if (no_log_file) {
-    initialize_log <- list(initialize = TRUE, timestamp = date_string)
+    initialize_log <- list()
     attr(initialize_log, "factory_name") <- base_name
+    attr(initialize_log, "initialized_at") <- date_string
     saveRDS(initialize_log, log_file_path)
   }
   

--- a/R/filter_log.R
+++ b/R/filter_log.R
@@ -67,14 +67,12 @@ filter_log <- function(log_file, match_exact_type = NULL,
   
   conds <- list(...)
   
+  results <- log_file
   if (!is.null(names(conds))) {
-    results <- filter_log_conditions(log_file, match_exact_type, ...)
-  } else {
-    ## return all log entries if no conds (remove initialize and timestamp)
-    results <- log_file[-c(1,2)]
+    results <- filter_log_conditions(results, match_exact_type, ...)
   }
-  
-  if (most_recent == TRUE & length(results) > 1) {
+
+    if (most_recent == TRUE & length(results) > 1) {
     results <- filter_log_most_recent(results)
   }
   

--- a/R/filter_log_most_recent.R
+++ b/R/filter_log_most_recent.R
@@ -7,7 +7,7 @@ filter_log_most_recent <- function(log_list) {
   
   name_keys <- grep("compile_init_env.file", ul_log_names, value = TRUE)
   unique_source_files <- unique(ul_log[name_keys])
-  
+
   timestamps_list <- list()
   for (i in seq_along(unique_source_files)) {
     ## get source filenames

--- a/tests/testthat/test_compile_report.R
+++ b/tests/testthat/test_compile_report.R
@@ -110,9 +110,10 @@ test_that("Compile logs activity in an rds file", {
   
   log_file <- readRDS(".compile_log.rds")
   expect_equal(attr(log_file, "factory_name"), factory_name)
+  init_time <- attr(log_file, "initialized_at")
+  expect_equal(as.Date(init_time), Sys.Date())
   
-  
-  log_entry <- log_file[[length(log_file)]]
+  log_entry <- log_file[[1]]
   other_param <- log_entry$compile_init_env$params$other
   expect_equal(other_param, "test")
   quiet_arg <- log_entry$compile_init_env$quiet
@@ -129,12 +130,12 @@ test_that("Compile logs activity in an rds file", {
   
   log_file <- readRDS(".compile_log.rds")
   
-  log_entry <- log_file[[length(log_file)]]
+  log_entry <- log_file[[2]]
   other_param <- log_entry$compile_init_env$params$other
   expect_equal(other_param, "two")
   log_dots_args <- log_entry$dots$extra
   expect_equal(is.data.frame(log_dots_args$lots), TRUE)
   log_output_dir <- log_entry$output_dir
   ## Expect to have the two initalize values plus two log entries
-  expect_equal(length(log_file), 4)
+  expect_equal(length(log_file), 2)
 })

--- a/tests/testthat/test_compile_report.R
+++ b/tests/testthat/test_compile_report.R
@@ -16,9 +16,14 @@ test_that("Compilation can handle multiple outputs", {
   outputs <- sort(outputs)
   ref <- c("figures/boxplots-1.pdf", "figures/boxplots-1.png",
            "figures/violins-1.pdf", "figures/violins-1.png",
-           "foo_2018-06-29.html", "outputs_base.csv" )
+           "foo_2018-06-29.html", "outputs_base.csv")
 
   expect_identical(ref, outputs)
+  
+  base_refs <- unlist(lapply(ref, basename))
+  log_entry <- readRDS(".compile_log.rds")[[1]]
+  log_outputs <- unlist(lapply(log_entry$output_files, basename))
+  expect_identical(base_refs, log_outputs)
 })
 
 test_that("Compilation can take params and pass to markdown::render", {

--- a/tests/testthat/test_filter_log.R
+++ b/tests/testthat/test_filter_log.R
@@ -53,7 +53,7 @@ test_that("Filtering returns only exact matches on EXACT parameters", {
                   "more" = list("thing" = "foo")),
     dots = dots_args)
   
-  expect_equal(non_missing_filtered, log_file[-c(1,2,3)])
+  expect_equal(non_missing_filtered, log_file[-c(1)])
 })
 
 
@@ -66,11 +66,11 @@ test_that("Filtering a list with string values returns log entries", {
   
   ## Expect the filtered list to be the same as the log entries of log_file
      ## (both entries match the filter)
-  expect_equal(filtered, log_file[-c(1,2)])
+  expect_equal(names(filtered), names(log_file))
   
   filtered <- filter_log(log_file, params = list("other" = "two"))
   
-  expect_equal(filtered, log_file[-c(1,2,3)])
+  expect_equal(filtered, log_file[-c(1)])
 })
 
 
@@ -83,7 +83,7 @@ test_that("Filtering with non-string values returns the matching lists", {
     dots = dots_args, 
     most_recent = FALSE)
 
-  expect_equal(filtered, log_file[-c(1,2,3)])
+  expect_equal(filtered, log_file[-c(1)])
 })
 
 
@@ -98,8 +98,8 @@ test_that("Filtering for most recent returns only last match for each source", {
   
   most_recent_filtered <- filter_log(log_file, most_recent = TRUE)
   
-  ## Without `most_recent = TRUE` this would be equal to log_file[-c(3,4,5)]
-  expect_equal(most_recent_filtered, log_file[c(4,5)])
+  ## Without `most_recent = TRUE` this would be equal to log_file[c(1,2,3)]
+  expect_equal(most_recent_filtered, log_file[c(2,3)])
 })
 
 test_that("Filtering can return outputs only", {


### PR DESCRIPTION
https://github.com/reconhub/reportfactory/issues/51

Only log entries are in the log list, other info stored as attributes

Removes unnecessary file from compile_log function