### PR TITLE
Update tests to run only necessary source compilation

### DIFF
--- a/tests/testthat/test_compile_report.R
+++ b/tests/testthat/test_compile_report.R
@@ -36,7 +36,7 @@ test_that("Compilation can take params and pass to markdown::render", {
   report <- list_reports(pattern = "foo")[1]
   
   foo_value <- "testzfoo"
-  update_reports(params = 
+  compile_report(report, params = 
                    list(foo = foo_value, show_stuff = TRUE, bar = letters))
   
   expect_match(

--- a/tests/testthat/test_new_factory.R
+++ b/tests/testthat/test_new_factory.R
@@ -110,7 +110,8 @@ test_that("working directory unchanged", {
   ## new_factory with move_in = FALSE should not alter the working directory
   expect_identical(odir, getwd())
 
-  update_reports(quiet = TRUE, factory = x)
+  test_report <- grep(list_reports(x), pattern = "contacts", value = TRUE)[1]
+  compile_report(test_report, quiet = TRUE, factory = x)
 
 
   ## update_reports should not alter the working directory

--- a/tests/testthat/test_new_factory.R
+++ b/tests/testthat/test_new_factory.R
@@ -110,7 +110,7 @@ test_that("working directory unchanged", {
   ## new_factory with move_in = FALSE should not alter the working directory
   expect_identical(odir, getwd())
 
-  test_report <- list_reports(pattern = "contacts")[1]
+  test_report <- list_reports(factory = x, pattern = "contacts")[1]
   compile_report(test_report, quiet = TRUE, factory = x)
 
 

--- a/tests/testthat/test_new_factory.R
+++ b/tests/testthat/test_new_factory.R
@@ -110,7 +110,7 @@ test_that("working directory unchanged", {
   ## new_factory with move_in = FALSE should not alter the working directory
   expect_identical(odir, getwd())
 
-  test_report <- grep(list_reports(x), pattern = "contacts", value = TRUE)[1]
+  test_report <- list_report(pattern = "contacts")
   compile_report(test_report, quiet = TRUE, factory = x)
 
 

--- a/tests/testthat/test_new_factory.R
+++ b/tests/testthat/test_new_factory.R
@@ -110,7 +110,7 @@ test_that("working directory unchanged", {
   ## new_factory with move_in = FALSE should not alter the working directory
   expect_identical(odir, getwd())
 
-  test_report <- list_report(pattern = "contacts")
+  test_report <- list_reports(pattern = "contacts")[1]
   compile_report(test_report, quiet = TRUE, factory = x)
 
 

--- a/tests/testthat/test_validate_factory.R
+++ b/tests/testthat/test_validate_factory.R
@@ -16,7 +16,7 @@ test_that("A new_factory is valid", {
     length(test$errors) == 0L && length(test$warnings) == 0L
   }
   expect_true(no_probs(validate_factory(x)))
-  test_report <- grep(list_reports(x), pattern = "contacts", value = TRUE)[1]
+  test_report <- list_report(pattern = "contacts")
   compile_report(test_report, quiet = TRUE, factory = x)
   
   expect_true(no_probs(validate_factory(x)))

--- a/tests/testthat/test_validate_factory.R
+++ b/tests/testthat/test_validate_factory.R
@@ -16,7 +16,9 @@ test_that("A new_factory is valid", {
     length(test$errors) == 0L && length(test$warnings) == 0L
   }
   expect_true(no_probs(validate_factory(x)))
-  update_reports(quiet = TRUE, factory = x)
+  test_report <- grep(list_reports(x), pattern = "contacts", value = TRUE)[1]
+  compile_report(test_report, quiet = TRUE, factory = x)
+  
   expect_true(no_probs(validate_factory(x)))
 
 })

--- a/tests/testthat/test_validate_factory.R
+++ b/tests/testthat/test_validate_factory.R
@@ -10,13 +10,13 @@ test_that("A new_factory is valid", {
     file.path(tempdir(), paste("factory_test", rnd, sep = "_"))
   }
 
-  new_factory(x <- new_dir(), move_in = FALSE, include_examples = TRUE)
+  new_factory(x <- new_dir(), move_in = TRUE, include_examples = TRUE)
 
   no_probs <- function(test) {
     length(test$errors) == 0L && length(test$warnings) == 0L
   }
   expect_true(no_probs(validate_factory(x)))
-  test_report <- list_report(pattern = "contacts")
+  test_report <- list_reports(pattern = "contacts")[1]
   compile_report(test_report, quiet = TRUE, factory = x)
   
   expect_true(no_probs(validate_factory(x)))

--- a/tests/testthat/test_validate_factory.R
+++ b/tests/testthat/test_validate_factory.R
@@ -18,7 +18,6 @@ test_that("A new_factory is valid", {
   expect_true(no_probs(validate_factory(x)))
   test_report <- list_reports(pattern = "contacts")[1]
   compile_report(test_report, quiet = TRUE, factory = x)
-  
   expect_true(no_probs(validate_factory(x)))
 
 })


### PR DESCRIPTION
https://github.com/reconhub/reportfactory/issues/55

MAKES THINGS PASS!


I tried to update the examples in `factory_template_with_examples.zip` but for some reason it wasn't working. We'll update that as a team later?